### PR TITLE
Update seq2seq_lstm.py

### DIFF
--- a/seq2seq_lstm.py
+++ b/seq2seq_lstm.py
@@ -113,6 +113,10 @@ def prepare_data(data_path, sample_indices, test_indices, shuffle=True):
         # Shuffle lines in data
         with io.open(data_path, 'r', encoding='utf-8') as f:
             data = [line.splitlines()[0] for line in f]
+        
+        for i in range(len(data)):
+            index = data[i].find('\tCC')
+            data[i] = data[i][0:index]
 
     # Vectorize the data.
     input_texts, target_texts, input_characters, target_characters = vectorize_data(data, sample_indices)


### PR DESCRIPTION
In the previous file, the dataset file was handled as there is only one tab space per line but in reality, the dataset provided by http://www.manythings.org/anki/  has two tab spaces per line that has to be removed. There is a common term '\tCC' in each line that has to be removed to run the dataset. I have added few lines of code to RECTIFY it. You can check at from line 117 to line 119. It worked for me. At least on non-shuffled dataset.